### PR TITLE
Bump minimum PHP to 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "forum": "https://discourse.laminas.dev/"
     },
     "require": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+        "php": "~8.1.0 || ~8.2.0"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.5.0",
@@ -39,7 +39,7 @@
     "config": {
         "sort-packages": true,
         "platform": {
-            "php": "8.0.99"
+            "php": "8.1.99"
         },
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

 Bump PHP to 8.1 since PHP 8.0 is security only and should not be used for new packages.